### PR TITLE
Correctly escape code examples in Lens.Action

### DIFF
--- a/src/Control/Lens/Action.hs
+++ b/src/Control/Lens/Action.hs
@@ -101,10 +101,12 @@ a ^! l = getEffect (l (Effect #. return) a)
 -- >>> ["ab","cd","ef"]^!!folded.acts
 -- ["ace","acf","ade","adf","bce","bcf","bde","bdf"]
 --
--- [1,2]^!!folded.act (\i -> putStr (show i ++ ": ") >> getLine).each.to succ
+-- @
+-- >>> [1,2]^!!folded.act (\i -> putStr (show i ++ ": ") >> getLine).each.to succ
 -- 1: aa
 -- 2: bb
 -- "bbcc"
+-- @
 (^!!) :: Monad m => s -> Acting m [a] s a -> m [a]
 a ^!! l = getEffect (l (Effect #. return . return) a)
 {-# INLINE (^!!) #-}
@@ -145,9 +147,11 @@ act sma pafb = cotabulate $ \ws -> effective $ do
 -- >>> (1,"hello")^!_2.acts.to succ
 -- "ifmmp"
 --
--- (1,getLine)^!!_2.acts.folded.to succ
+-- @
+-- >>> (1,getLine)^!!_2.acts.folded.to succ
 -- aa
 -- "bb"
+-- @
 acts :: IndexPreservingAction m (m a) a
 acts = act id
 {-# INLINE acts #-}


### PR DESCRIPTION
The haddock code examples for `(^!!)` and `acts` where not escaped with `@`.

I added `@` around the examples and also `>>>` for the first line.

[![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)](http://24pullrequests.com)

Best,
Markus
