### PR TITLE
lens-action.cabal: added missing Control.Lens.Action.Type to tarball

### DIFF
--- a/lens-action.cabal
+++ b/lens-action.cabal
@@ -49,6 +49,7 @@ library
     Control.Lens.Action
     Control.Lens.Action.Internal
     Control.Lens.Action.Reified
+    Control.Lens.Action.Type
 
   cpp-options: -traditional
 


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <siarheit@google.com>